### PR TITLE
Add localStorage persistence for profiles

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1,1 +1,41 @@
 //localstorage handling
+
+const STORAGE_KEY = "devhub_profiles"
+const THEME_KEY = 'devhub_theme'
+
+//save profiles array to local storage
+function saveProfiles(profiles) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles))
+        console.log(" profile saved successfully on", new Date().toLocaleString())
+    } catch (err) {
+        console.error("Could not save profile:", err)
+    }
+}
+
+
+//let's now load profile saved from the local storage
+
+function loadProfiles() {
+    try {
+        const data = localStorage.getItem(STORAGE_KEY)
+        if (data) {
+            return JSON.parse(data)
+        }
+        else{
+            return [];
+        }
+    } catch(err){
+        console.error("could not load profiles", err);
+        return []
+    }
+}
+
+
+// clearing profiles
+
+function clearProfiles(){
+    localStorage.removeItem(STORAGE_KEY)
+}
+
+export { saveProfiles, loadProfiles, clearProfiles};

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,33 +1,31 @@
 //localstorage handling
 
-const STORAGE_KEY = "devhub_profiles"
-const THEME_KEY = 'devhub_theme'
+const STORAGE_KEY = "devhub_profiles";
 
 //save profiles array to local storage
 function saveProfiles(profiles) {
     try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles))
-        console.log(" profile saved successfully on", new Date().toLocaleString())
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+        console.log(" profile saved successfully on", new Date().toLocaleString());
     } catch (err) {
-        console.error("Could not save profile:", err)
+        console.error("Could not save profile:", err);
     }
 }
-
 
 //let's now load profile saved from the local storage
 
 function loadProfiles() {
     try {
-        const data = localStorage.getItem(STORAGE_KEY)
+        const data = localStorage.getItem(STORAGE_KEY);
         if (data) {
-            return JSON.parse(data)
+            return JSON.parse(data);
         }
         else{
             return [];
         }
     } catch(err){
         console.error("could not load profiles", err);
-        return []
+        return [];
     }
 }
 
@@ -35,7 +33,7 @@ function loadProfiles() {
 // clearing profiles
 
 function clearProfiles(){
-    localStorage.removeItem(STORAGE_KEY)
+    localStorage.removeItem(STORAGE_KEY);
 }
 
 export { saveProfiles, loadProfiles, clearProfiles};


### PR DESCRIPTION
Implemented saveProfiles(), loadProfiles(), and clearProfiles() in /js/storage.js.
Profiles now persist after page reload using localStorage.
Includes error handling and console logs for debugging.